### PR TITLE
add a command line parameter to pass a unique name to use for creating

### DIFF
--- a/cmd/metrics/metrics.go
+++ b/cmd/metrics/metrics.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"math/rand"
 	"os/signal"
+	"strconv"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/prometheus/client_golang/prometheus"
@@ -134,6 +136,7 @@ func main() {
 	fHosts := flag.Int("h", 1, "No of hosts : Sample hosts required (default 1).")
 	fPlugins := flag.Int("p", 100, "No of plugins: Sample plugins per host(default 100).")
 	fIterations := flag.Int("t", 1, "No of times to run sample data (default 1) -1 for ever.")
+	fUniqueName := flag.String("uname", "metrics-"+strconv.Itoa(rand.Intn(100)), "Unique name across application")
 
 	flag.Parse()
 
@@ -158,6 +161,7 @@ func main() {
 				PluginCount: *fPlugins, //No of plugin count per hosts
 				DataCount:   *fIterations,
 			},
+			UniqueName: *fUniqueName,
 		}
 
 	}
@@ -262,7 +266,7 @@ func main() {
 		///Metric Listener
 		amqpMetricsurl := fmt.Sprintf("amqp://%s", serverConfig.AMQP1MetricURL)
 		log.Printf("Connecting to AMQP1 : %s\n", amqpMetricsurl)
-		amqpMetricServer = amqp10.NewAMQPServer(amqpMetricsurl, serverConfig.Debug, serverConfig.DataCount, serverConfig.Prefetch, amqpHandler, done, *fTestServer)
+		amqpMetricServer = amqp10.NewAMQPServer(amqpMetricsurl, serverConfig.Debug, serverConfig.DataCount, serverConfig.Prefetch, amqpHandler, done, *fTestServer, *fUniqueName)
 		log.Printf("Listening.....\n")
 
 		if serverConfig.TestServer == true {

--- a/internal/pkg/amqp/receiver.go
+++ b/internal/pkg/amqp/receiver.go
@@ -56,6 +56,7 @@ type AMQPServer struct {
 	method      func(s *AMQPServer) (electron.Receiver, error)
 	prefetch    int
 	amqpHandler *AMQPHandler
+	uniqueName  string
 }
 
 //AMQPHandler ...
@@ -75,7 +76,7 @@ func MockAmqpServer(notifier chan string) *AMQPServer {
 }
 
 //NewAMQPServer   ...
-func NewAMQPServer(urlStr string, debug bool, msgcount int, prefetch int, amqpHanlder *AMQPHandler, done chan bool, isTest bool) *AMQPServer {
+func NewAMQPServer(urlStr string, debug bool, msgcount int, prefetch int, amqpHanlder *AMQPHandler, done chan bool, isTest bool, uniqueName string) *AMQPServer {
 	if len(urlStr) == 0 {
 		log.Println("No URL provided")
 		//usage()
@@ -95,6 +96,7 @@ func NewAMQPServer(urlStr string, debug bool, msgcount int, prefetch int, amqpHa
 			done:        done,
 			prefetch:    prefetch,
 			amqpHandler: amqpHanlder,
+			uniqueName:  uniqueName,
 		}
 	} else {
 		server = &AMQPServer{
@@ -108,6 +110,7 @@ func NewAMQPServer(urlStr string, debug bool, msgcount int, prefetch int, amqpHa
 			done:        done,
 			prefetch:    prefetch,
 			amqpHandler: amqpHanlder,
+			uniqueName:  uniqueName,
 		}
 	}
 
@@ -305,7 +308,7 @@ msgloop:
 func (s *AMQPServer) connect() (electron.Receiver, error) {
 	// Wait for one goroutine per URL
 	// Make name unique-ish
-	container := electron.NewContainer(fmt.Sprintf("rcv[%v]", os.Args[0]))
+	container := electron.NewContainer(fmt.Sprintf("rcv[%v]", s.uniqueName))
 	//connections := make(chan electron.Connection, 1) // Connections to close on exit
 	url, err := amqp.ParseURL(s.urlStr)
 	debugr("Parsing %s\n", s.urlStr)

--- a/internal/pkg/amqp/receiver_test.go
+++ b/internal/pkg/amqp/receiver_test.go
@@ -13,7 +13,7 @@ func TestPut(t *testing.T) {
 
 	done := make(chan bool)
 
-	amqpServer = NewAMQPServer(url, true, 10, 0, nil, done, false)
+	amqpServer = NewAMQPServer(url, true, 10, 0, nil, done, false, "metrics-test")
 
 	for i := 0; i < 10; i++ {
 		data := <-amqpServer.notifier

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -18,6 +18,7 @@ type EventConfiguration struct {
 	PublishEventEnabled bool
 	ResetIndex          bool
 	Prefetch            int
+	UniqueName          string
 	IgnoreString        string `json:"-"`
 }
 
@@ -39,6 +40,7 @@ type MetricConfiguration struct {
 	DataCount      int //-1 for ever which is default
 	UseSample      bool
 	Sample         SampleDataConfig
+	UniqueName     string
 	IgnoreString   string `json:"-"`
 }
 


### PR DESCRIPTION
the proton container.  The name must be unique across all parts of the
distributed application.

In a kubernetes environment, pass the name of the pod.